### PR TITLE
Bump influxdb service plan from tiny to small

### DIFF
--- a/deployment/site.tf
+++ b/deployment/site.tf
@@ -105,7 +105,7 @@ module "prometheus" {
     1789721 # notify
   ]
 
-  influxdb_service_plan = "tiny-1_x"
+  influxdb_service_plan = "small-1_x"
 
   paas_exporter_username = data.pass_password.prometheus_exporter_username.password
   paas_exporter_password = data.pass_password.prometheus_exporter_password.password


### PR DESCRIPTION
PaaS were told that our 16GB disk instance was running out of disk
space, so we need to bump this up while we figure out retention policies
and other specs.

These are the changes between the plans:

     tiny-1.x     1 dedicated VM, 2 CPU per VM, 4GB RAM per VM, 16GB disk space
     small-1.x    1 dedicated VM, 2 CPU per VM, 8GB RAM per VM, 50GB disk space