### PR TITLE
Add PaaS Redis metrics datasource to external exporters

### DIFF
--- a/deployment/input.tf
+++ b/deployment/input.tf
@@ -22,4 +22,12 @@ locals {
       app_name = pair[1]
     }
   }
+
+  external_apps = [{
+    name            = "PaaS Redis"
+    endpoint        = "redis.metrics.cloud.service.gov.uk/metrics"
+    scrape_interval = "300s"
+    auth_username   = data.pass_password.prometheus_exporter_username.password
+    auth_password   = data.pass_password.prometheus_exporter_password.password
+  }]
 }

--- a/deployment/input.tf
+++ b/deployment/input.tf
@@ -25,9 +25,10 @@ locals {
 
   external_apps = [{
     name            = "PaaS Redis"
-    endpoint        = "redis.metrics.cloud.service.gov.uk/metrics"
+    endpoint        = "redis.metrics.cloud.service.gov.uk"
     scrape_interval = "300s"
     auth_username   = data.pass_password.prometheus_exporter_username.password
     auth_password   = data.pass_password.prometheus_exporter_password.password
+    name_prefix     = "paas_redis"
   }]
 }

--- a/deployment/site.tf
+++ b/deployment/site.tf
@@ -42,6 +42,8 @@ module "prometheus" {
 
   internal_apps = concat(local.cross_space_apps, keys(local.internal_apps))
 
+  external_exporters = local.external_apps
+
   prometheus_disk_quota          = 4096
   prometheus_memory              = 4096
   prometheus_basic_auth_password = data.pass_password.basic_auth_password.password

--- a/prometheus/input.tf
+++ b/prometheus/input.tf
@@ -52,6 +52,8 @@ locals {
       scheme          = contains(keys(exporter), "scheme") ? exporter.scheme : "https"
       honor_labels    = contains(keys(exporter), "honor_labels") ? exporter.honor_labels : false
       scrape_interval = contains(keys(exporter), "scrape_interval") ? exporter.scrape_interval : local.default_scrape_interval
+      auth_username   = contains(keys(exporter), "auth_username") ? exporter.auth_username : ""
+      auth_password   = contains(keys(exporter), "auth_password") ? exporter.auth_password : ""
     }
   ]
   default_internal_app_port = "8080"

--- a/prometheus/input.tf
+++ b/prometheus/input.tf
@@ -54,6 +54,7 @@ locals {
       scrape_interval = contains(keys(exporter), "scrape_interval") ? exporter.scrape_interval : local.default_scrape_interval
       auth_username   = contains(keys(exporter), "auth_username") ? exporter.auth_username : ""
       auth_password   = contains(keys(exporter), "auth_password") ? exporter.auth_password : ""
+      name_prefix     = contains(keys(exporter), "name_prefix") ? exporter.name_prefix : ""
     }
   ]
   default_internal_app_port = "8080"

--- a/prometheus/templates/prometheus.yml.tmpl
+++ b/prometheus/templates/prometheus.yml.tmpl
@@ -25,6 +25,11 @@ scrape_configs:
     scheme: ${exporter.scheme}
     honor_labels: ${exporter.honor_labels}
     scrape_interval: ${exporter.scrape_interval}
+    %{ if exporter.auth_username != "" }
+    basic_auth:
+      username: ${exporter.auth_username}
+      password: ${exporter.auth_password}
+    ${ endif }
     static_configs:
       - targets: [${exporter.endpoint}]
     metric_relabel_configs:

--- a/prometheus/templates/prometheus.yml.tmpl
+++ b/prometheus/templates/prometheus.yml.tmpl
@@ -29,10 +29,17 @@ scrape_configs:
     basic_auth:
       username: ${exporter.auth_username}
       password: ${exporter.auth_password}
-    ${ endif }
+    %{ endif }
     static_configs:
       - targets: [${exporter.endpoint}]
     metric_relabel_configs:
+    %{ if exporter.name_prefix != "" }
+      - action: replace
+        source_labels: [__name__]
+        target_label: __name__
+        regex: (.*)
+        replacement: ${exporter.name_prefix}_$${1}
+    %{ endif }
       - regex: guid
         action: labeldrop
       - source_labels: [space]

--- a/prometheus_all/input.tf
+++ b/prometheus_all/input.tf
@@ -148,12 +148,6 @@ variable "prometheus_shared_token" { default = "" }
 locals {
   list_of_redis_exporters    = [for redis_module in module.redis_prometheus_exporter : redis_module.exporter]
   list_of_postgres_exporters = [for postgres_module in module.postgres_prometheus_exporter : postgres_module.exporter]
-  list_of_external_exporters = [for endpoint in var.external_exporters :
-    {
-      endpoint = endpoint
-      name     = endpoint
-      scheme   = "https"
-    }
-  ]
+  list_of_external_exporters = var.external_exporters
   prometheus_yearly_endpoint = var.enable_prometheus_yearly ? module.prometheus_yearly[0].endpoint : ""
 }


### PR DESCRIPTION
Add PaaS Redis metrics datasource to external exporters

Also adds support for basic auth credentials required by the PaaS
hosted metrics data source.

See details here: https://github.com/alphagov/paas-prometheus-endpoints/tree/main/src/redis