### PR TITLE
Bump influxdb plan from small to medium

### DIFF
--- a/deployment/site.tf
+++ b/deployment/site.tf
@@ -35,7 +35,7 @@ module "prometheus" {
     }
   ]
 
-  influxdb_service_plan = "small-1_x"
+  influxdb_service_plan = "medium-1_x"
 
   paas_exporter_username = data.pass_password.prometheus_exporter_username.password
   paas_exporter_password = data.pass_password.prometheus_exporter_password.password


### PR DESCRIPTION
This will give us more memory (15GB instead of 8GB) and more disk space
(140GB instead of 50GB)