### PR TITLE
Increase memory of readonly to 8GB

### DIFF
--- a/deployment/site.tf
+++ b/deployment/site.tf
@@ -46,6 +46,7 @@ module "prometheus" {
 
   prometheus_disk_quota          = 4096
   prometheus_memory              = 4096
+  prometheus_readonly_memory     = 8192
   prometheus_basic_auth_password = data.pass_password.basic_auth_password.password
   prometheus_shared_token        = data.pass_password.prometheus_shared_token.password
 }

--- a/prometheus_all/input.tf
+++ b/prometheus_all/input.tf
@@ -93,10 +93,17 @@ variable "docker_credentials" {
     password = ""
   }
 }
+
 variable "prometheus_memory" {
   description = "Override default prometheus application allocated memory. See Prometheus module for current default value."
   default     = ""
 }
+
+variable "prometheus_readonly_memory" {
+  description = "Override readonly prometheus application allocated memory. See Prometheus module for current default value."
+  default     = ""
+}
+
 variable "prometheus_disk_quota" {
   description = "Override default prometheus application allocated disk space. See Prometheus module for current default value."
   default     = ""

--- a/prometheus_all/resources.tf
+++ b/prometheus_all/resources.tf
@@ -50,7 +50,7 @@ module "prometheus_readonly" {
   monitoring_instance_name     = "readonly-${var.monitoring_instance_name}"
   monitoring_space_id          = data.cloudfoundry_space.monitoring.id
   influxdb_service_instance_id = module.influxdb[0].service_instance_id
-  memory                       = var.prometheus_memory
+  memory                       = var.prometheus_readonly_memory
   disk_quota                   = var.prometheus_disk_quota
   readonly                     = true
   docker_credentials           = var.docker_credentials


### PR DESCRIPTION
```
Terraform will perform the following actions:

  # module.prometheus.module.prometheus_readonly[0].cloudfoundry_app.prometheus will be updated in-place
  ~ resource "cloudfoundry_app" "prometheus" {
        id                   = "3e0f2859-f66d-47c4-878d-cb82249bbe4b"
      ~ memory               = 4096 -> 8192
        name                 = "prometheus-readonly-notify"
        # (16 unchanged attributes hidden)


        # (2 unchanged blocks hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```