### PR TITLE
Add emergency-alerts github team to our Grafana

### DIFF
--- a/deployment/site.tf
+++ b/deployment/site.tf
@@ -15,7 +15,8 @@ module "prometheus" {
   grafana_github_client_id     = data.pass_password.grafana_github_client_id.password
   grafana_github_client_secret = data.pass_password.grafana_github_client_secret.password
   grafana_github_team_ids = [
-    1789721 # notify
+    1789721, # notify
+    6754132, # emergency-alerts
   ]
 
   grafana_aws_datasources = [


### PR DESCRIPTION
This is low risk as they only have view permissions and can't see anything sensitive. This means they can get up and running quicker so they can focus on more important things

```
Terraform will perform the following actions:

  # module.prometheus.module.grafana[0].cloudfoundry_app.grafana will be updated in-place
  ~ resource "cloudfoundry_app" "grafana" {
        id                         = "187fdb9f-3b4c-4eda-b2df-a604f4c49502"
        name                       = "grafana-notify"
      ~ source_code_hash           = "3n5psUZXWaoHbjvSkqaGgZe3OJBIiJuBzWZfzLIxmLc=" -> "HeWUWWYthgd7X+EDGSQ4kCJUCqC7sti2pOopDD9jZo0="
        # (19 unchanged attributes hidden)

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```