### PR TITLE
Switch grafana to use cflinuxfs4

### DIFF
--- a/grafana/resources.tf
+++ b/grafana/resources.tf
@@ -18,6 +18,7 @@ resource "cloudfoundry_app" "grafana" {
   path             = data.archive_file.config.output_path
   source_code_hash = data.archive_file.config.output_base64sha256
   buildpack        = "https://github.com/SpringerPE/cf-grafana-buildpack"
+  stack            = "cflinuxfs4"
   routes {
     route = cloudfoundry_route.grafana.id
   }


### PR DESCRIPTION
What
----

Switch grafana to use the PaaS cflinuxfs4 stack.

Why
----

cflinuxfs3 is currently the default on the PaaS. This is based off ubuntu 18.04. This stopped receiving updates after Apr 2023.

cflinuxfs4 will become the default on the PaaS after 27 Nov 2023.

The intention is to migrate all applications to cflinuxfs4 eventually.